### PR TITLE
Add option to delay requests by a specified amount of milliseconds

### DIFF
--- a/src/jQuery.ajaxQueue.js
+++ b/src/jQuery.ajaxQueue.js
@@ -10,10 +10,12 @@ $.ajaxQueue = function( ajaxOpts ) {
 
     // run the actual query
     function doRequest( next ) {
-        jqXHR = $.ajax( ajaxOpts );
-        jqXHR.done( dfd.resolve )
-            .fail( dfd.reject )
-            .then( next, next );
+        setTimeout(function() {
+            jqXHR = $.ajax( ajaxOpts );
+            jqXHR.done( dfd.resolve )
+                .fail( dfd.reject )
+                .then( next, next );
+        }, ajaxOpts.delay||0);
     }
 
     // queue our ajax request


### PR DESCRIPTION
default is of course 0 if not specified, works like this:

```js
		$.ajaxQueue({
			url: 'https://httpbin.org/get',
			delay: 1000
		}).done(function(data) {
			console.log('success');
			console.log(data);
		}).fail(function() {
			console.log('failed');
		});
```